### PR TITLE
Extended $all operator to handle string values

### DIFF
--- a/src/dexie.mongoify.js
+++ b/src/dexie.mongoify.js
@@ -69,9 +69,13 @@ var comparsionQueryOperatorsImpl = {
 
     $all: function(key, value) {
         return function(item) {
-            return has(item, key) && value.every(function(valueItem) {
-                return item[key].indexOf(valueItem) > -1;
-            });
+           if (value.every) {
+               return has(item, key) && value.every(function(valueItem) {
+                   return item[key].indexOf(valueItem) > -1;
+               });
+            } else {
+                return has(item, key) && item[key].indexOf(value) > -1;
+            }
         };
     },
 


### PR DESCRIPTION
Since the $in operator works with arrays and strings it makes sense to add this ability to the $all operator as well.