### PR TITLE
Update `.collection()` method to work with multiple dbs

### DIFF
--- a/src/dexie.mongoify.js
+++ b/src/dexie.mongoify.js
@@ -796,7 +796,7 @@ dexie = dexie.default || dexie;
 dexie.addons.push(function(db) {
 
     dexie.prototype.collection = function collection(collectionName) {
-        return db.table(collectionName);
+        return this.table(collectionName);
     };
 
     db.Table.prototype.count = function count(query) {


### PR DESCRIPTION
By using the `db` parameter passed in by Dexie when constructing a new instance, every time a new instance is created, the `collection` method works only on the latest DB. This breaks use cases such as ours when testing multi-device sync, creating a `backend` DB and multiple `client` DBs.